### PR TITLE
Update transaction properties

### DIFF
--- a/airbyte-integrations/connectors/source-plaid/integration_tests/catalog.json
+++ b/airbyte-integrations/connectors/source-plaid/integration_tests/catalog.json
@@ -107,7 +107,7 @@
             "merchant_name": { "type": ["string", "null"] },
             "pending_transaction_id": { "type": ["string", "null"] },
             "personal_finance_category": {
-              "type": "object",
+              "type": ["object", "null"],
               "properties": {
                 "primary": { "type": "string" },
                 "detailed": { "type": "string" },

--- a/airbyte-integrations/connectors/source-plaid/integration_tests/catalog.json
+++ b/airbyte-integrations/connectors/source-plaid/integration_tests/catalog.json
@@ -42,37 +42,50 @@
             "account_id",
             "amount",
             "iso_currency_code",
-            "name",
             "transaction_id",
             "category",
             "date",
-            "transaction_type"
+            "original_description",
+            "payment_channel"
           ],
           "properties": {
             "account_id": { "type": "string" },
             "amount": { "type": "number" },
             "category": { "type": "array", "items": { "type": "string" } },
             "category_id": { "type": ["string", "null"] },
+            "counterparties": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": { "type": "string" },
+                  "entity_id": { "type": ["string", "null"] },
+                  "type": { "type": "string" },
+                  "reference_number": { "type": ["string", "null"] },
+                  "website": { "type": ["string", "null"] },
+                  "confidence_level": { "type": ["string", "null"] }
+                }
+              }
+            },
             "date": { "type": "string" },
             "iso_currency_code": { "type": "string" },
-            "name": { "type": "string" },
-            "payment_channel": { "type": ["string", "null"] },
-            "pending": { "type": ["boolean", "null"] },
+            "payment_channel": { "type": "string" },
+            "pending": { "type": "boolean" },
             "transaction_id": { "type": "string" },
-            "transaction_type": { "type": "string" },
             "location": {
               "type": ["object", "null"],
               "properties": {
                 "address": { "type": ["string", "null"] },
                 "city": { "type": ["string", "null"] },
                 "country": { "type": ["string", "null"] },
-                "lat": { "type": ["string", "null"] },
-                "lon": { "type": ["string", "null"] },
+                "lat": { "type": ["number", "null"] },
+                "lon": { "type": ["number", "null"] },
                 "postal_code": { "type": ["string", "null"] },
                 "region": { "type": ["string", "null"] },
                 "store_number": { "type": ["string", "null"] }
               }
             },
+            "original_description": { "type": ["string", "null"] },
             "payment_meta": {
               "type": ["object", "null"],
               "properties": {
@@ -93,9 +106,16 @@
             "datetime": { "type": ["string", "null"] },
             "merchant_name": { "type": ["string", "null"] },
             "pending_transaction_id": { "type": ["string", "null"] },
-            "personal_finance_category": { "type": ["string", "null"] },
-            "transaction_code": { "type": ["string", "null"] },
-            "unofficial_currency_code": { "type": ["string", "null"] }
+            "personal_finance_category": {
+              "type": "object",
+              "properties": {
+                "primary": { "type": "string" },
+                "detailed": { "type": "string" },
+                "confidence_level": { "type": ["string", "null"] }
+              },
+              "transaction_code": { "type": ["string", "null"] },
+              "unofficial_currency_code": { "type": ["string", "null"] }
+            }
           }
         }
       }

--- a/airbyte-integrations/connectors/source-plaid/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-plaid/integration_tests/configured_catalog.json
@@ -108,7 +108,7 @@
             "merchant_name": { "type": ["string", "null"] },
             "pending_transaction_id": { "type": ["string", "null"] },
             "personal_finance_category": {
-              "type": "object",
+              "type": ["object", "null"],
               "properties": {
                 "primary": { "type": "string" },
                 "detailed": { "type": "string" },

--- a/airbyte-integrations/connectors/source-plaid/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-plaid/integration_tests/configured_catalog.json
@@ -43,37 +43,50 @@
             "account_id",
             "amount",
             "iso_currency_code",
-            "name",
             "transaction_id",
             "category",
             "date",
-            "transaction_type"
+            "original_description",
+            "payment_channel"
           ],
           "properties": {
             "account_id": { "type": "string" },
             "amount": { "type": "number" },
             "category": { "type": "array", "items": { "type": "string" } },
             "category_id": { "type": ["string", "null"] },
+            "counterparties": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": { "type": "string" },
+                  "entity_id": { "type": ["string", "null"] },
+                  "type": { "type": "string" },
+                  "reference_number": { "type": ["string", "null"] },
+                  "website": { "type": ["string", "null"] },
+                  "confidence_level": { "type": ["string", "null"] }
+                }
+              }
+            },
             "date": { "type": "string" },
             "iso_currency_code": { "type": "string" },
-            "name": { "type": "string" },
-            "payment_channel": { "type": ["string", "null"] },
-            "pending": { "type": ["boolean", "null"] },
+            "payment_channel": { "type": "string" },
+            "pending": { "type": "boolean" },
             "transaction_id": { "type": "string" },
-            "transaction_type": { "type": "string" },
             "location": {
               "type": ["object", "null"],
               "properties": {
                 "address": { "type": ["string", "null"] },
                 "city": { "type": ["string", "null"] },
                 "country": { "type": ["string", "null"] },
-                "lat": { "type": ["string", "null"] },
-                "lon": { "type": ["string", "null"] },
+                "lat": { "type": ["number", "null"] },
+                "lon": { "type": ["number", "null"] },
                 "postal_code": { "type": ["string", "null"] },
                 "region": { "type": ["string", "null"] },
                 "store_number": { "type": ["string", "null"] }
               }
             },
+            "original_description": { "type": ["string", "null"] },
             "payment_meta": {
               "type": ["object", "null"],
               "properties": {
@@ -94,9 +107,16 @@
             "datetime": { "type": ["string", "null"] },
             "merchant_name": { "type": ["string", "null"] },
             "pending_transaction_id": { "type": ["string", "null"] },
-            "personal_finance_category": { "type": ["string", "null"] },
-            "transaction_code": { "type": ["string", "null"] },
-            "unofficial_currency_code": { "type": ["string", "null"] }
+            "personal_finance_category": {
+              "type": "object",
+              "properties": {
+                "primary": { "type": "string" },
+                "detailed": { "type": "string" },
+                "confidence_level": { "type": ["string", "null"] }
+              },
+              "transaction_code": { "type": ["string", "null"] },
+              "unofficial_currency_code": { "type": ["string", "null"] }
+            }
           }
         }
       },

--- a/airbyte-integrations/connectors/source-plaid/integration_tests/configured_catalog_incremental.json
+++ b/airbyte-integrations/connectors/source-plaid/integration_tests/configured_catalog_incremental.json
@@ -108,7 +108,7 @@
             "merchant_name": { "type": ["string", "null"] },
             "pending_transaction_id": { "type": ["string", "null"] },
             "personal_finance_category": {
-              "type": "object",
+              "type": ["object", "null"],
               "properties": {
                 "primary": { "type": "string" },
                 "detailed": { "type": "string" },

--- a/airbyte-integrations/connectors/source-plaid/integration_tests/configured_catalog_incremental.json
+++ b/airbyte-integrations/connectors/source-plaid/integration_tests/configured_catalog_incremental.json
@@ -43,37 +43,50 @@
             "account_id",
             "amount",
             "iso_currency_code",
-            "name",
             "transaction_id",
             "category",
             "date",
-            "transaction_type"
+            "original_description",
+            "payment_channel"
           ],
           "properties": {
             "account_id": { "type": "string" },
             "amount": { "type": "number" },
             "category": { "type": "array", "items": { "type": "string" } },
             "category_id": { "type": ["string", "null"] },
+            "counterparties": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": { "type": "string" },
+                  "entity_id": { "type": ["string", "null"] },
+                  "type": { "type": "string" },
+                  "reference_number": { "type": ["string", "null"] },
+                  "website": { "type": ["string", "null"] },
+                  "confidence_level": { "type": ["string", "null"] }
+                }
+              }
+            },
             "date": { "type": "string" },
             "iso_currency_code": { "type": "string" },
-            "name": { "type": "string" },
-            "payment_channel": { "type": ["string", "null"] },
-            "pending": { "type": ["boolean", "null"] },
+            "payment_channel": { "type": "string" },
+            "pending": { "type": "boolean" },
             "transaction_id": { "type": "string" },
-            "transaction_type": { "type": "string" },
             "location": {
               "type": ["object", "null"],
               "properties": {
                 "address": { "type": ["string", "null"] },
                 "city": { "type": ["string", "null"] },
                 "country": { "type": ["string", "null"] },
-                "lat": { "type": ["string", "null"] },
-                "lon": { "type": ["string", "null"] },
+                "lat": { "type": ["number", "null"] },
+                "lon": { "type": ["number", "null"] },
                 "postal_code": { "type": ["string", "null"] },
                 "region": { "type": ["string", "null"] },
                 "store_number": { "type": ["string", "null"] }
               }
             },
+            "original_description": { "type": ["string", "null"] },
             "payment_meta": {
               "type": ["object", "null"],
               "properties": {
@@ -94,9 +107,16 @@
             "datetime": { "type": ["string", "null"] },
             "merchant_name": { "type": ["string", "null"] },
             "pending_transaction_id": { "type": ["string", "null"] },
-            "personal_finance_category": { "type": ["string", "null"] },
-            "transaction_code": { "type": ["string", "null"] },
-            "unofficial_currency_code": { "type": ["string", "null"] }
+            "personal_finance_category": {
+              "type": "object",
+              "properties": {
+                "primary": { "type": "string" },
+                "detailed": { "type": "string" },
+                "confidence_level": { "type": ["string", "null"] }
+              },
+              "transaction_code": { "type": ["string", "null"] },
+              "unofficial_currency_code": { "type": ["string", "null"] }
+            }
           }
         }
       },

--- a/airbyte-integrations/connectors/source-plaid/source_plaid/manifest.yaml
+++ b/airbyte-integrations/connectors/source-plaid/source_plaid/manifest.yaml
@@ -218,8 +218,6 @@ streams:
             type:
               - string
               - "null"
-          name:
-            type: string
           original_description:
             type:
               - string

--- a/airbyte-integrations/connectors/source-plaid/source_plaid/manifest.yaml
+++ b/airbyte-integrations/connectors/source-plaid/source_plaid/manifest.yaml
@@ -281,6 +281,9 @@ streams:
                 type:
                   - string
                   - "null"
+            type:
+              - object
+              - "null"
           transaction_code:
             type:
               - string

--- a/airbyte-integrations/connectors/source-plaid/source_plaid/manifest.yaml
+++ b/airbyte-integrations/connectors/source-plaid/source_plaid/manifest.yaml
@@ -145,6 +145,28 @@ streams:
             type:
               - string
               - "null"
+          counterparties:
+            items:
+              properties:
+                name:
+                  type:
+                    - string
+                entity_id:
+                  type:
+                    - string
+                    - "null"
+                type:
+                  type:
+                    - string
+                website:
+                  type:
+                    - string
+                    - "null"
+                confidence_level:
+                  type:
+                    - string
+                    - "null"
+            type: array
           date:
             type: string
           datetime:
@@ -152,7 +174,9 @@ streams:
               - string
               - "null"
           iso_currency_code:
-            type: string
+            type:
+              - string
+              - "null"
           location:
             properties:
               address:
@@ -169,11 +193,11 @@ streams:
                   - "null"
               lat:
                 type:
-                  - string
+                  - number
                   - "null"
               lon:
                 type:
-                  - string
+                  - number
                   - "null"
               postal_code:
                 type:
@@ -196,10 +220,13 @@ streams:
               - "null"
           name:
             type: string
-          payment_channel:
+          original_description:
             type:
               - string
               - "null"
+          payment_channel:
+            type:
+              - string
           payment_meta:
             properties:
               by_order_of:
@@ -240,22 +267,27 @@ streams:
           pending:
             type:
               - boolean
-              - "null"
           pending_transaction_id:
             type:
               - string
               - "null"
           personal_finance_category:
-            type:
-              - string
-              - "null"
+            properties:
+              primary:
+                type:
+                  - string
+              detailed:
+                type:
+                  - string
+              confidence_level:
+                type:
+                  - string
+                  - "null"
           transaction_code:
             type:
               - string
               - "null"
           transaction_id:
-            type: string
-          transaction_type:
             type: string
           unofficial_currency_code:
             type:

--- a/airbyte-integrations/connectors/source-plaid/source_plaid/manifest.yaml
+++ b/airbyte-integrations/connectors/source-plaid/source_plaid/manifest.yaml
@@ -309,7 +309,7 @@ streams:
       requester:
         type: HttpRequester
         url_base: https://{{config['plaid_env']}}.plaid.com
-        path: /transactions/get
+        path: /transactions/sync
         http_method: POST
         request_parameters: {}
         request_headers: {}
@@ -317,8 +317,11 @@ streams:
           type: NoAuth
         request_body_json:
           secret: "{{config['api_key']}}"
+          cursor: "{{ next_page_token['next_page_token'] }}"
+          count: 500
           options:
-            offset: "{{ next_page_token['next_page_token'] }}"
+            include_original_description: true
+            days_requested: 730
           client_id: "{{config['client_id']}}"
           access_token: "{{config['access_token']}}"
       record_selector:

--- a/airbyte-integrations/connectors/source-plaid/source_plaid/manifest.yaml
+++ b/airbyte-integrations/connectors/source-plaid/source_plaid/manifest.yaml
@@ -301,7 +301,8 @@ streams:
           - transaction_id
           - category
           - date
-          - transaction_type
+          - original_description
+          - payment_channel
         type: object
     retriever:
       type: SimpleRetriever


### PR DESCRIPTION
## What

Updates the properties of a transaction to match the current state at https://plaid.com/docs/api/products/transactions/#transactionssync.

## How

Adds / removes properties from the Plaid YAML file. Updates test files (I think??) to match.



## User Impact

None yet; I didn't add `transaction` as a syncable stream since pagination and incremental sync are still broken.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
