### PR TITLE
Remove wrong yaml

### DIFF
--- a/airbyte-integrations/connectors/source-plaid/source_plaid/manifest.yaml
+++ b/airbyte-integrations/connectors/source-plaid/source_plaid/manifest.yaml
@@ -336,26 +336,6 @@ streams:
         type: DefaultPaginator
         pagination_strategy:
           type: OffsetIncrement
-    incremental_sync:
-      type: DatetimeBasedCursor
-      cursor_field: date
-      datetime_format: "%Y-%m-%d"
-      start_time_option:
-        type: RequestOption
-        field_name: start_date
-        inject_into: body_json
-      end_time_option:
-        type: RequestOption
-        field_name: end_date
-        inject_into: body_json
-      start_datetime:
-        type: MinMaxDatetime
-        datetime: "{{config['start_date']}}"
-        datetime_format: "%Y-%m-%d"
-      end_datetime:
-        type: MinMaxDatetime
-        datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
-        datetime_format: "%Y-%m-%dT%H:%M:%SZ"
 spec:
   connection_specification:
     $schema: http://json-schema.org/draft-07/schema#

--- a/airbyte-integrations/connectors/source-plaid/source_plaid/manifest.yaml
+++ b/airbyte-integrations/connectors/source-plaid/source_plaid/manifest.yaml
@@ -318,7 +318,7 @@ streams:
           type: NoAuth
         request_body_json:
           secret: "{{config['api_key']}}"
-          cursor: "{{ next_page_token['next_page_token'] }}"
+          cursor: null
           count: 500
           options:
             include_original_description: true


### PR DESCRIPTION
## What

- The Plaid-specific sync tests did not work because incremental sync and pagination are implemented wrong in the code we inherited.
- So I deleted the implementations to make syncing work.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
