### PR TITLE
Parse transactions

### DIFF
--- a/airbyte-integrations/connectors/source-plaid/source_plaid/components.py
+++ b/airbyte-integrations/connectors/source-plaid/source_plaid/components.py
@@ -1,0 +1,42 @@
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Mapping
+
+import requests
+
+from airbyte_cdk.sources.declarative.decoders.decoder import Decoder
+from airbyte_cdk.sources.declarative.decoders.json_decoder import JsonDecoder
+from airbyte_cdk.sources.declarative.extractors.record_extractor import RecordExtractor
+
+
+@dataclass
+class PlaidTransactionExtractor(RecordExtractor):
+    """
+    Record extractor that searches a decoded response over multiple paths. Each field is
+    a separate path that points to an array (unless it doesn't exist at all).
+
+    If the field path points to an array, that array is returned.
+    If the field path points to a non-existing path, an empty array is returned.
+
+    Example of instantiating this transform:
+    ```
+      extractor:
+        type: CustomRecordExtractor
+        class_name: source_plaid.components.PlaidTransactionExtractor
+        field_path:
+          - "added"
+          - "modified"
+    ```
+
+    Attributes:
+        field_path (list[str]): Path to the fields that should be extracted
+        decoder (Decoder): The decoder responsible to transfom the response in a Mapping
+    """
+
+    field_path: list[str]
+    decoder: Decoder = field(default_factory=lambda: JsonDecoder(parameters={}))
+
+    def extract_records(self, response: requests.Response) -> Iterable[Mapping[str, Any]]:
+        body = self.decoder.decode(response)
+        for path in self.field_path:
+            extracted = body.get(path, [])
+            yield from extracted

--- a/airbyte-integrations/connectors/source-plaid/source_plaid/manifest.yaml
+++ b/airbyte-integrations/connectors/source-plaid/source_plaid/manifest.yaml
@@ -328,10 +328,11 @@ streams:
       record_selector:
         type: RecordSelector
         extractor:
-          type: DpathExtractor
+          type: CustomRecordExtractor
+          class_name: source_plaid.components.PlaidTransactionExtractor
           field_path:
-            - transactions
-            - "*"
+            - "added"
+            - "modified"
       paginator:
         type: DefaultPaginator
         pagination_strategy:

--- a/airbyte-integrations/connectors/source-plaid/source_plaid/manifest.yaml
+++ b/airbyte-integrations/connectors/source-plaid/source_plaid/manifest.yaml
@@ -318,7 +318,7 @@ streams:
           type: NoAuth
         request_body_json:
           secret: "{{config['api_key']}}"
-          cursor: null
+          cursor: "{{ next_page_token.next_page_token }}"
           count: 500
           options:
             include_original_description: true
@@ -335,7 +335,9 @@ streams:
       paginator:
         type: DefaultPaginator
         pagination_strategy:
-          type: OffsetIncrement
+          type: CursorPagination
+          cursor_value: "{{ response.get('next_cursor') }}"
+          stop_condition: "{{ response.has_more is false }}"
 spec:
   connection_specification:
     $schema: http://json-schema.org/draft-07/schema#


### PR DESCRIPTION
## What
- Ingest transaction data that's been added or modified.
- Doesn't ingest deleted transaction info because we don't get whole transaction objects, just IDs. We'll need to handle that separately.

## How
- Overrides the default RecordSelector with a custom one, `source_plaid.components.PlaidTransactionExtractor`.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
